### PR TITLE
Remove sha256

### DIFF
--- a/please.rb
+++ b/please.rb
@@ -2,7 +2,6 @@ class Please < Formula
   desc "High-performance extensible build system for reproducible builds."
   homepage "https://please.build"
   url "https://github.com/thought-machine/please/archive/v15.12.0.tar.gz"
-  sha256 "6953ed196d8871ce977ff5649a6ebf40371bd699f09204560e8083ae140babf1"
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
Tarballs produced by GitHub are not stable, so the sha256 is not guaranteed to be correct.

```
==> Downloading from https://codeload.github.com/thought-machine/please/tar.gz/v15.12.0
Error: SHA256 mismatch
Expected: 6953ed196d8871ce977ff5649a6ebf40371bd699f09204560e8083ae140babf1
  Actual: fe11729610b01fc5df28aa2a61850d4d39b71d0ab0facbafb73fd7b7561b9c38
    File: .../4121f49838f0f56f21958cee32230d03c963d79bcd169be10b132bb736b668ae--please-15.12.0.tar.gz
To retry an incomplete download, remove the file above.
```

Homebrew can still install formulae without a sha256, it'll just print a warning:

```
==> Downloading https://github.com/thought-machine/please/archive/v15.12.0.tar.gz
Warning: Cannot verify integrity of '4121f49838f0f56f21958cee32230d03c963d79bcd169be10b132bb736b668ae--please-15.12.0.tar.gz'.
No checksum was provided for this resource.
For your reference, the checksum is:
  sha256 "fe11729610b01fc5df28aa2a61850d4d39b71d0ab0facbafb73fd7b7561b9c38"
```

Fixes #1