### PR TITLE
Fix deprecated v3 formular that causes unable to perform `brew tap thought-machine/please`

### DIFF
--- a/please.rb
+++ b/please.rb
@@ -1,27 +1,29 @@
+# typed: false
+# frozen_string_literal: true
+
 class Please < Formula
-  desc "High-performance extensible build system for reproducible builds."
+  desc "High-performance extensible build system for reproducible builds"
   homepage "https://please.build"
   url "https://github.com/thought-machine/please/archive/v16.6.0.tar.gz"
   sha256 "6953ed196d8871ce977ff5649a6ebf40371bd699f09204560e8083ae140babf1"
+  bottle do
+    root_url "https://github.com/thought-machine/homebrew-please/releases/download/v16.6.0"
+    sha256 cellar: :any_skip_relocation, el_capitan:   "1bee420ecefeeb387ffe180ed31871cf0a041b4d3dbb894f09c343149d4c5bfc"
+    sha256 cellar: :any_skip_relocation, yosemite:     "8559b3191138df25cc449173e0c19f383180c4d04576ef2821ccd4ac4b9ed180"
+    sha256 cellar: :any_skip_relocation, mojave:       "c6435a30fb80b18d09873f8139e64bbc58950d5a68e7f18db2ac654e9ec3e848"
+    sha256 cellar: :any_skip_relocation, linux_x86_64: "787755c4f5ebc1695e3aaf0ed7ac86a85e3bbecdac3d0aa047626a9f3b25ef80"
+  end
+
   depends_on "go" => :build
 
   def install
-    system "./bootstrap.sh --skip_tests"
+    system "./bootstrap.sh", "--skip_tests"
     libexec.install Dir["plz-out/gen/package/*"]
     bin.install_symlink libexec/"please"
   end
 
   test do
-    system "plz init"
-    system "plz build ///pleasings//go:all"
-  end
-
-  bottle do
-    root_url "https://github.com/thought-machine/homebrew-please/releases/download/v16.6.0"
-    cellar :any_skip_relocation
-    sha256 "1bee420ecefeeb387ffe180ed31871cf0a041b4d3dbb894f09c343149d4c5bfc" => :el_capitan
-    sha256 "8559b3191138df25cc449173e0c19f383180c4d04576ef2821ccd4ac4b9ed180" => :yosemite
-    sha256 "c6435a30fb80b18d09873f8139e64bbc58950d5a68e7f18db2ac654e9ec3e848" => :mojave
-    sha256 "787755c4f5ebc1695e3aaf0ed7ac86a85e3bbecdac3d0aa047626a9f3b25ef80" => :linux_x86_64
+    system "plz", "init"
+    system "plz", "build", "///pleasings//go:all"
   end
 end


### PR DESCRIPTION
Here is the error that I got
```
❯ brew tap thought-machine/please
Updating Homebrew...
==> Tapping thought-machine/please
Cloning into '/usr/local/Homebrew/Library/Taps/thought-machine/homebrew-please'...
remote: Enumerating objects: 355, done.
remote: Counting objects: 100% (126/126), done.
remote: Compressing objects: 100% (84/84), done.
remote: Total 355 (delta 82), reused 86 (delta 42), pack-reused 229
Receiving objects: 100% (355/355), 61.49 KiB | 262.00 KiB/s, done.
Resolving deltas: 100% (219/219), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/thought-machine/homebrew-please/please.rb
please: Calling `cellar` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the thought-machine/please tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/thought-machine/homebrew-please/please.rb:21

Error: Cannot tap thought-machine/please: invalid syntax in tap!
```
So, I create this PR to fix this issue.