### PR TITLE
Fix invalid SHA256

### DIFF
--- a/please.rb
+++ b/please.rb
@@ -6,7 +6,7 @@ class Please < Formula
   desc "High-performance extensible build system for reproducible builds"
   homepage "https://please.build"
   url "https://github.com/thought-machine/please/archive/v16.12.1.tar.gz"
-  sha256 "6953ed196d8871ce977ff5649a6ebf40371bd699f09204560e8083ae140babf1"
+  sha256 "d05d89f1f77a8ceb438a78d23edf02e0ab7a2c3516076239c0871fef18fffd3d"
   bottle do
     root_url "https://github.com/thought-machine/homebrew-please/releases/download/v16.12.1"
     sha256 cellar: :any_skip_relocation, el_capitan: "aca780ebe9718c38ed55a203820a46679a00675028ccb71da9b4105e44911d8b"


### PR DESCRIPTION
Fix an issue unable to install because of invalid SHA256
```
❯ brew install please
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 5 formulae.

==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.17.2
Already downloaded: /Users/pichet/Library/Caches/Homebrew/downloads/d3e60ec09348a7c69ac49620d5755b91ad1d018b49be5662b4e577ccc645582a--go-1.17.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/go/blobs/sha256:b0a1686c5c5ba668e78a97d66567e9d007f7d2a0c9b1a53e79841e3736d729e6
Already downloaded: /Users/pichet/Library/Caches/Homebrew/downloads/5ab07362116ba3a5785df6399a31792327c0d3d7ae56b64095415291cee6de9e--go--1.17.2.arm64_big_sur.bottle.tar.gz
==> Downloading https://github.com/thought-machine/please/archive/v16.12.1.tar.gz
Already downloaded: /Users/pichet/Library/Caches/Homebrew/downloads/b4603f832d8c4377682a5c56ea2e5effffd1032f1ff5517cecce790c91320cfb--please-16.12.1.tar.gz
Error: please: SHA256 mismatch
Expected: 6953ed196d8871ce977ff5649a6ebf40371bd699f09204560e8083ae140babf1
  Actual: d05d89f1f77a8ceb438a78d23edf02e0ab7a2c3516076239c0871fef18fffd3d
    File: /Users/pichet/Library/Caches/Homebrew/downloads/b4603f832d8c4377682a5c56ea2e5effffd1032f1ff5517cecce790c91320cfb--please-16.12.1.tar.gz
To retry an incomplete download, remove the file above.
```

And it may be related to https://github.com/thought-machine/homebrew-please/issues/10