### PR TITLE
Bump version of ubuntu from 20190226 to 20250318

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: "2.1"
 jobs:
     build:
       docker:
-       - image: thoughtmachine/please_ubuntu:20190226
+       - image: ghcr.io/thought-machine/please_ubuntu:20250318
       steps:
        - add_ssh_keys:
            fingerprints:


### PR DESCRIPTION
Bump from `thoughtmachine/please_ubuntu:20190226` to `ghcr.io/thought-machine/please_ubuntu:20250318`